### PR TITLE
Correct base path

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -23,7 +23,7 @@ const Redirector = () => {
 
 export default function Routes() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <DomRoutes>
         <Route path="/welcome" Component={WelcomeView} />
         <Route path="/register" Component={RegisterView} />


### PR DESCRIPTION
There was a problem that `planetarium.github.io/web9c` goes to `planetarium.github.io/{welcome,login,...}`.

https://vitejs.dev/guide/build.html#public-base-path